### PR TITLE
android: move dependency to libgralloc_drm

### DIFF
--- a/src/egl/Android.mk
+++ b/src/egl/Android.mk
@@ -55,9 +55,9 @@ LOCAL_SHARED_LIBRARIES := \
 	libhardware \
 	liblog \
 	libcutils \
-	libgralloc_drm \
 
 ifeq ($(ENABLE_FLINK_SUPPORT),1)
+LOCAL_SHARED_LIBRARIES += libgralloc_drm
 LOCAL_CFLAGS += -DHAS_GRALLOC_DRM_HEADERS
 endif
 


### PR DESCRIPTION
drm_gralloc header files are only included under
ENABLE_FLINK_SUPPORT, so should dependency to
libgralloc_drm.

Jira: None

Test: Build without libgralloc_drm

Signed-off-by: Marta Lofstedt <marta.lofstedt@intel.com>