### PR TITLE
Call unlock after using lockFlex

### DIFF
--- a/src/egl/drivers/dri2/egl_dri2.h
+++ b/src/egl/drivers/dri2/egl_dri2.h
@@ -223,6 +223,7 @@ struct dri2_egl_display
    gralloc1_device_t *gralloc1_dvc;
    GRALLOC1_PFN_LOCK_FLEX pfn_lockflex;
    GRALLOC1_PFN_GET_FORMAT pfn_getFormat;
+   GRALLOC1_PFN_UNLOCK pfn_unlock;
 #endif
 
    int                       is_render_node;

--- a/src/egl/drivers/dri2/platform_android.c
+++ b/src/egl/drivers/dri2/platform_android.c
@@ -819,7 +819,8 @@ droid_create_image_from_prime_fd_yuv(_EGLDisplay *disp, _EGLContext *ctx,
         _eglLog(_EGL_WARNING, "gralloc->lockflex failed: %d", ret);
         return NULL;
      }
-
+     int outReleaseFence = 0;
+     dri2_dpy->pfn_unlock(dri2_dpy->gralloc1_dvc, buf->handle, &outReleaseFence);
    } else {
 
      const gralloc_module_t *gralloc0;
@@ -1357,6 +1358,9 @@ dri2_initialize_android(_EGLDriver *drv, _EGLDisplay *dpy)
 
         dri2_dpy->pfn_getFormat = (GRALLOC1_PFN_GET_FORMAT)\
              dri2_dpy->gralloc1_dvc->getFunction(dri2_dpy->gralloc1_dvc, GRALLOC1_FUNCTION_GET_FORMAT);
+
+        dri2_dpy->pfn_unlock = (GRALLOC1_PFN_UNLOCK)\
+             dri2_dpy->gralloc1_dvc->getFunction(dri2_dpy->gralloc1_dvc, GRALLOC1_FUNCTION_UNLOCK);
       }
    }
 


### PR DESCRIPTION
lockFlex function will lock the buffer and provide information
on how to access the data planes. Clients should call unlock to
unlock the buffer.

Jira: None
Test: Device boots

Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>