### PR TITLE
Fix capture not working with YCbCr_420_888 in Android

### DIFF
--- a/src/egl/drivers/dri2/platform_android.c
+++ b/src/egl/drivers/dri2/platform_android.c
@@ -692,11 +692,11 @@ static int get_ycbcr_from_flexlayout(struct android_flex_layout *outFlexLayout, 
        switch(outFlexLayout->planes[i].component){
          case FLEX_COMPONENT_Y:
              ycbcr->y = outFlexLayout->planes[i].top_left;
-             ycbcr->ystride = outFlexLayout->planes[i].h_increment;
+             ycbcr->ystride = outFlexLayout->planes[i].v_increment;
          break;
          case FLEX_COMPONENT_Cb:
              ycbcr->cb = outFlexLayout->planes[i].top_left;
-             ycbcr->cstride = outFlexLayout->planes[i].h_increment;
+             ycbcr->cstride = outFlexLayout->planes[i].v_increment;
          break;
          case FLEX_COMPONENT_Cr:
              ycbcr->cr = outFlexLayout->planes[i].top_left;


### PR DESCRIPTION
Mapping of FlexLayOut parameters to ycbcr not done
correctly causing camera app to crash.

As per doc, ystride is the Y slice index delta between
vertically adjacent pixes and cstride is the cb and cr slice
index delta between vertically adjacent pixels. So, v_increment
has to be mapped to strides.

Fix the issues by setting strides to v_increment.

Tests done:
- Image capture
- Video recording and playback

Change-Id: Idbfd6eb14f5a22b31b33eeb501369e991c297bcb
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>