### PR TITLE
Mesa Static link with libexpat

### DIFF
--- a/src/gallium/targets/dri/Android.mk
+++ b/src/gallium/targets/dri/Android.mk
@@ -42,8 +42,14 @@ LOCAL_LDFLAGS := \
 LOCAL_SHARED_LIBRARIES := \
 	libdl \
 	libglapi \
-	libexpat \
 	libz
+
+# Android sdk versions >=26 MESA should static link libexpat while <26 should dynamic link
+ifeq ($(filter 23 24 25, $(PLATFORM_SDK_VERSION)),)
+LOCAL_SHARED_LIBRARIES += libexpat
+else
+LOCAL_STATIC_LIBRARIES := libexpat
+endif
 
 $(foreach d, $(MESA_BUILD_GALLIUM), $(eval LOCAL_CFLAGS += $(patsubst HAVE_%,-D%,$(d))))
 

--- a/src/intel/Android.common.mk
+++ b/src/intel/Android.common.mk
@@ -38,7 +38,14 @@ LOCAL_C_INCLUDES := \
 	$(MESA_TOP)/src/mapi \
 	$(MESA_TOP)/src/mesa
 
-LOCAL_SHARED_LIBRARIES := libexpat libz
+LOCAL_SHARED_LIBRARIES := libz
+
+# Android sdk versions >=26 MESA should static link libexpat while <26 should dynamic link
+ifeq ($(filter 23 24 25, $(PLATFORM_SDK_VERSION)),)
+LOCAL_SHARED_LIBRARIES += libexpat
+else
+LOCAL_STATIC_LIBRARIES := libexpat
+endif
 
 LOCAL_WHOLE_STATIC_LIBRARIES := libmesa_genxml
 

--- a/src/mesa/drivers/dri/Android.mk
+++ b/src/mesa/drivers/dri/Android.mk
@@ -49,10 +49,15 @@ MESA_DRI_WHOLE_STATIC_LIBRARIES := \
 MESA_DRI_SHARED_LIBRARIES := \
 	libcutils \
 	libdl \
-	libexpat \
 	libglapi \
 	liblog \
 	libz
+# Android sdk versions >=26 MESA should static link libexpat while <26 should dynamic link
+ifeq ($(filter 23 24 25, $(PLATFORM_SDK_VERSION)),)
+MESA_DRI_SHARED_LIBRARIES += libexpat
+else
+MESA_DRI_WHOLE_STATIC_LIBRARIES += libexpat
+endif
 
 #-----------------------------------------------
 # Build drivers and libmesa_dri_common

--- a/src/util/Android.mk
+++ b/src/util/Android.mk
@@ -41,8 +41,12 @@ LOCAL_C_INCLUDES := \
 	$(MESA_TOP)/src/gallium/include \
 	$(MESA_TOP)/src/gallium/auxiliary
 
-LOCAL_SHARED_LIBRARIES := \
-	libexpat
+# Android sdk versions >=26 MESA should static link libexpat while <26 should dynamic link
+ifeq ($(filter 23 24 25, $(PLATFORM_SDK_VERSION)),)
+LOCAL_SHARED_LIBRARIES := libexpat
+else
+LOCAL_STATIC_LIBRARIES := libexpat
+endif
 
 LOCAL_MODULE := libmesa_util
 


### PR DESCRIPTION
In Android O, MESA needs to statically link libexpat
so that it's in same namespace.

Change-Id: I82b0be5c817c21e734dfdf5bfb6a9aa1d414ab33
Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>