### PR TITLE
Suppress compile warnings on Android

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -68,14 +68,22 @@ LOCAL_CFLAGS += \
 	-DHAVE_DL_ITERATE_PHDR \
 	-DMAJOR_IN_SYSMACROS \
 	-fvisibility=hidden \
-	-Wno-sign-compare
+	-Wno-sign-compare \
+	-Wno-self-assign \
+	-Wno-constant-logical-operand \
+	-Wno-format \
+	-Wno-incompatible-pointer-types \
+	-Wno-enum-conversion
 
 LOCAL_CPPFLAGS += \
 	-D__STDC_CONSTANT_MACROS \
 	-D__STDC_FORMAT_MACROS \
 	-D__STDC_LIMIT_MACROS \
 	-Wno-error=non-virtual-dtor \
-	-Wno-non-virtual-dtor
+	-Wno-non-virtual-dtor \
+	-Wno-delete-non-virtual-dtor \
+	-Wno-overloaded-virtual \
+	-Wno-missing-braces
 
 # mesa requires at least c99 compiler
 LOCAL_CONLYFLAGS += \


### PR DESCRIPTION
Jira: None.
Test: Build passes on Android and no warnings reported.