### PR TITLE
Revert "egl: EXT_pixel_format_float plumbing"

### DIFF
--- a/src/egl/drivers/dri2/egl_dri2.c
+++ b/src/egl/drivers/dri2/egl_dri2.c
@@ -695,8 +695,6 @@ dri2_setup_screen(_EGLDisplay *disp)
       dri2_renderer_query_integer(dri2_dpy,
                                   __DRI2_RENDERER_HAS_CONTEXT_PRIORITY);
 
-   disp->Extensions.EXT_pixel_format_float = EGL_TRUE;
-
    if (dri2_renderer_query_integer(dri2_dpy,
                                    __DRI2_RENDERER_HAS_FRAMEBUFFER_SRGB))
       disp->Extensions.KHR_gl_colorspace = EGL_TRUE;

--- a/src/egl/main/eglapi.c
+++ b/src/egl/main/eglapi.c
@@ -514,7 +514,6 @@ _eglCreateExtensionsString(_EGLDisplay *dpy)
    _EGL_CHECK_EXTENSION(KHR_surfaceless_context);
    if (dpy->Extensions.EXT_swap_buffers_with_damage)
       _eglAppendExtension(&exts, "EGL_KHR_swap_buffers_with_damage");
-   _EGL_CHECK_EXTENSION(EXT_pixel_format_float);
    _EGL_CHECK_EXTENSION(KHR_wait_sync);
 
    if (dpy->Extensions.KHR_no_config_context)

--- a/src/egl/main/eglconfig.c
+++ b/src/egl/main/eglconfig.c
@@ -68,7 +68,6 @@ _eglInitConfig(_EGLConfig *conf, _EGLDisplay *dpy, EGLint id)
    conf->TransparentType = EGL_NONE;
    conf->NativeVisualType = EGL_NONE;
    conf->ColorBufferType = EGL_RGB_BUFFER;
-   conf->ComponentType = EGL_COLOR_COMPONENT_TYPE_FIXED_EXT;
 }
 
 
@@ -255,9 +254,6 @@ static const struct {
    { EGL_RECORDABLE_ANDROID,        ATTRIB_TYPE_BOOLEAN,
                                     ATTRIB_CRITERION_EXACT,
                                     EGL_DONT_CARE },
-   { EGL_COLOR_COMPONENT_TYPE_EXT,  ATTRIB_TYPE_ENUM,
-                                    ATTRIB_CRITERION_EXACT,
-                                    EGL_COLOR_COMPONENT_TYPE_FIXED_EXT },
 };
 
 
@@ -318,11 +314,6 @@ _eglValidateConfig(const _EGLConfig *conf, EGLBoolean for_matching)
             break;
          case EGL_COLOR_BUFFER_TYPE:
             if (val != EGL_RGB_BUFFER && val != EGL_LUMINANCE_BUFFER)
-               valid = EGL_FALSE;
-            break;
-         case EGL_COLOR_COMPONENT_TYPE_EXT:
-            if (val != EGL_COLOR_COMPONENT_TYPE_FIXED_EXT &&
-                val != EGL_COLOR_COMPONENT_TYPE_FLOAT_EXT)
                valid = EGL_FALSE;
             break;
          default:

--- a/src/egl/main/eglconfig.h
+++ b/src/egl/main/eglconfig.h
@@ -88,7 +88,6 @@ struct _egl_config
    EGLint YInvertedNOK;
    EGLint FramebufferTargetAndroid;
    EGLint RecordableAndroid;
-   EGLint ComponentType;
 };
 
 
@@ -138,7 +137,6 @@ _eglOffsetOfConfig(EGLint attr)
    ATTRIB_MAP(EGL_Y_INVERTED_NOK,            YInvertedNOK);
    ATTRIB_MAP(EGL_FRAMEBUFFER_TARGET_ANDROID, FramebufferTargetAndroid);
    ATTRIB_MAP(EGL_RECORDABLE_ANDROID,        RecordableAndroid);
-   ATTRIB_MAP(EGL_COLOR_COMPONENT_TYPE_EXT,  ComponentType);
 #undef ATTRIB_MAP
    default:
       return -1;

--- a/src/egl/main/egldisplay.h
+++ b/src/egl/main/egldisplay.h
@@ -103,7 +103,6 @@ struct _egl_extensions
    EGLBoolean EXT_create_context_robustness;
    EGLBoolean EXT_image_dma_buf_import;
    EGLBoolean EXT_image_dma_buf_import_modifiers;
-   EGLBoolean EXT_pixel_format_float;
    EGLBoolean EXT_swap_buffers_with_damage;
 
    unsigned int IMG_context_priority;


### PR DESCRIPTION
This reverts commit 41f7de477c68a5ae3fd8b086dfb4a8cc10a35c39.
This patch makes Android enable wide color gamut support which
results in whitescreen after boot.

Android Boot log for reference [MR1]:
11-11 11:11:23.225  3359  3408 I zygote64:
android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::
hasWideColorDisplay retrieved: 0
11-11 11:11:23.225  3359  3408 I OpenGLRenderer: Initialized EGL,
version 1.4
11-11 11:11:23.225  3359  3408 D OpenGLRenderer: Swap behavior 2
11-11 11:11:23.225  3359  3408 F OpenGLRenderer: Device claims gide
gamut support, cannot find matching config, error = EGL_SUCCESS
--------- beginning of crash
11-11 11:11:23.225  3359  3408 F libc    : Fatal signal 6 (SIGABRT),
code -6 in tid 3408 (RenderThread), pid 3359 (ndroid.settings)

Jira: None
Test: Boot to Android Home screen
Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>