### PR TITLE
Disable EGL_KHR_gl_colorspace for dEQP wide color tests

### DIFF
--- a/src/egl/drivers/dri2/egl_dri2.c
+++ b/src/egl/drivers/dri2/egl_dri2.c
@@ -698,7 +698,7 @@ dri2_setup_screen(_EGLDisplay *disp)
 
    if (dri2_renderer_query_integer(dri2_dpy,
                                    __DRI2_RENDERER_HAS_FRAMEBUFFER_SRGB))
-      disp->Extensions.KHR_gl_colorspace = EGL_TRUE;
+      disp->Extensions.KHR_gl_colorspace = EGL_FALSE;
 
    if (dri2_dpy->image_driver ||
        (dri2_dpy->dri2 && dri2_dpy->dri2->base.version >= 3) ||


### PR DESCRIPTION
Change-Id: I11a42a7af1e874c4e771bb64390d5baf79638d6c
Jira: None.
Test: Android CTS should PASS for below
      dEQP-EGL.functional.wide_color#pbuffer_8888_colorspace_srgb
      dEQP-EGL.functional.wide_color#window_8888_colorspace_srgb
Signed-off-by: Kevin Strasser <kevin.strasser@intel.com>
Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>