### PR TITLE
Disable EXT_pixel_format_float for Android CtsViewTestCases

### DIFF
--- a/src/egl/drivers/dri2/egl_dri2.c
+++ b/src/egl/drivers/dri2/egl_dri2.c
@@ -696,6 +696,8 @@ dri2_setup_screen(_EGLDisplay *disp)
       dri2_renderer_query_integer(dri2_dpy,
                                   __DRI2_RENDERER_HAS_CONTEXT_PRIORITY);
 
+   disp->Extensions.EXT_pixel_format_float = EGL_TRUE;
+
    if (dri2_renderer_query_integer(dri2_dpy,
                                    __DRI2_RENDERER_HAS_FRAMEBUFFER_SRGB))
       disp->Extensions.KHR_gl_colorspace = EGL_FALSE;

--- a/src/egl/drivers/dri2/egl_dri2.c
+++ b/src/egl/drivers/dri2/egl_dri2.c
@@ -696,7 +696,7 @@ dri2_setup_screen(_EGLDisplay *disp)
       dri2_renderer_query_integer(dri2_dpy,
                                   __DRI2_RENDERER_HAS_CONTEXT_PRIORITY);
 
-   disp->Extensions.EXT_pixel_format_float = EGL_TRUE;
+   disp->Extensions.EXT_pixel_format_float = EGL_FALSE;
 
    if (dri2_renderer_query_integer(dri2_dpy,
                                    __DRI2_RENDERER_HAS_FRAMEBUFFER_SRGB))

--- a/src/egl/drivers/dri2/egl_dri2.c
+++ b/src/egl/drivers/dri2/egl_dri2.c
@@ -698,7 +698,7 @@ dri2_setup_screen(_EGLDisplay *disp)
 
    if (dri2_renderer_query_integer(dri2_dpy,
                                    __DRI2_RENDERER_HAS_FRAMEBUFFER_SRGB))
-      disp->Extensions.KHR_gl_colorspace = EGL_TRUE;
+      disp->Extensions.KHR_gl_colorspace = EGL_FALSE;
 
    if (dri2_dpy->image_driver ||
        (dri2_dpy->dri2 && dri2_dpy->dri2->base.version >= 3) ||

--- a/src/egl/main/eglapi.c
+++ b/src/egl/main/eglapi.c
@@ -515,6 +515,7 @@ _eglCreateExtensionsString(_EGLDisplay *dpy)
    _EGL_CHECK_EXTENSION(KHR_surfaceless_context);
    if (dpy->Extensions.EXT_swap_buffers_with_damage)
       _eglAppendExtension(&exts, "EGL_KHR_swap_buffers_with_damage");
+   _EGL_CHECK_EXTENSION(EXT_pixel_format_float);
    _EGL_CHECK_EXTENSION(KHR_wait_sync);
 
    if (dpy->Extensions.KHR_no_config_context)

--- a/src/egl/main/eglconfig.c
+++ b/src/egl/main/eglconfig.c
@@ -68,6 +68,7 @@ _eglInitConfig(_EGLConfig *conf, _EGLDisplay *dpy, EGLint id)
    conf->TransparentType = EGL_NONE;
    conf->NativeVisualType = EGL_NONE;
    conf->ColorBufferType = EGL_RGB_BUFFER;
+   conf->ComponentType = EGL_COLOR_COMPONENT_TYPE_FIXED_EXT;
 }
 
 
@@ -254,6 +255,9 @@ static const struct {
    { EGL_RECORDABLE_ANDROID,        ATTRIB_TYPE_BOOLEAN,
                                     ATTRIB_CRITERION_EXACT,
                                     EGL_DONT_CARE },
+   { EGL_COLOR_COMPONENT_TYPE_EXT,  ATTRIB_TYPE_ENUM,
+                                    ATTRIB_CRITERION_EXACT,
+                                    EGL_COLOR_COMPONENT_TYPE_FIXED_EXT },
 };
 
 
@@ -314,6 +318,11 @@ _eglValidateConfig(const _EGLConfig *conf, EGLBoolean for_matching)
             break;
          case EGL_COLOR_BUFFER_TYPE:
             if (val != EGL_RGB_BUFFER && val != EGL_LUMINANCE_BUFFER)
+               valid = EGL_FALSE;
+            break;
+         case EGL_COLOR_COMPONENT_TYPE_EXT:
+            if (val != EGL_COLOR_COMPONENT_TYPE_FIXED_EXT &&
+                val != EGL_COLOR_COMPONENT_TYPE_FLOAT_EXT)
                valid = EGL_FALSE;
             break;
          default:

--- a/src/egl/main/eglconfig.h
+++ b/src/egl/main/eglconfig.h
@@ -88,6 +88,7 @@ struct _egl_config
    EGLint YInvertedNOK;
    EGLint FramebufferTargetAndroid;
    EGLint RecordableAndroid;
+   EGLint ComponentType;
 };
 
 
@@ -137,6 +138,7 @@ _eglOffsetOfConfig(EGLint attr)
    ATTRIB_MAP(EGL_Y_INVERTED_NOK,            YInvertedNOK);
    ATTRIB_MAP(EGL_FRAMEBUFFER_TARGET_ANDROID, FramebufferTargetAndroid);
    ATTRIB_MAP(EGL_RECORDABLE_ANDROID,        RecordableAndroid);
+   ATTRIB_MAP(EGL_COLOR_COMPONENT_TYPE_EXT,  ComponentType);
 #undef ATTRIB_MAP
    default:
       return -1;

--- a/src/egl/main/egldisplay.h
+++ b/src/egl/main/egldisplay.h
@@ -104,6 +104,7 @@ struct _egl_extensions
    EGLBoolean EXT_create_context_robustness;
    EGLBoolean EXT_image_dma_buf_import;
    EGLBoolean EXT_image_dma_buf_import_modifiers;
+   EGLBoolean EXT_pixel_format_float;
    EGLBoolean EXT_swap_buffers_with_damage;
 
    unsigned int IMG_context_priority;


### PR DESCRIPTION
Android CTS should PASS for below
  android.view.cts.PixelCopyTest#testWideGamutWindowProducerCopyToRGBA16F
