### PR TITLE
Jennycao/fix for compile warnings

### DIFF
--- a/src/mesa/main/get.c
+++ b/src/mesa/main/get.c
@@ -3002,7 +3002,7 @@ _mesa_GetFixedv(GLenum pname, GLfixed *params)
       break;
 
    case TYPE_ENUM16:
-      params[0] = INT_TO_FIXED(((GLenum16 *) p)[0]);
+      params[0] = INT_TO_FIXED((GLint)(((GLenum16 *) p)[0]));
       break;
 
    case TYPE_INT_N:


### PR DESCRIPTION
    update to fix compile warning -W#warnings,  -Wtautological-constant-out-of-range-compare, ignore the compile warning -Wgnu-variable-sized-type-not-at-end, -Wmissing-bra
    
    update to fix compile warning "Deprecated: don't include cutils/log.h, use either android/log.h or log/log.h" -W#warnings,

     update UINT_TO_FIXED(I) to force cast the I to GLint to avoid the compile warning when type is GLenum16 --  "constant -32768 with expression of type 'GLenum16' (aka 'unsigned short') is always false
 -Wtautologicalia-constant-out-of-range-compare,

    ignore the compile warning: field 'base' with variable sized type 'struct drm_i915_query_topology_info' 
not at the end of a struct or class is a GNU extension -Wgnu-variable-sized-type-not-at-end,

    ignore the compile warning: suggest braces around initialization of subobject -Wmissing-braces
    
    Jira: GSE-1411
    Tests: compilation with warning clean