### PR TITLE
ignore some compile warning on android

### DIFF
--- a/src/compiler/Android.nir.mk
+++ b/src/compiler/Android.nir.mk
@@ -41,6 +41,9 @@ LOCAL_C_INCLUDES := \
 	$(MESA_TOP)/src/gallium/include \
 	$(MESA_TOP)/src/gallium/auxiliary
 
+LOCAL_CFLAGS := \
+        -Wno-missing-braces
+
 LOCAL_STATIC_LIBRARIES := libmesa_compiler
 
 LOCAL_MODULE := libmesa_nir

--- a/src/intel/Android.dev.mk
+++ b/src/intel/Android.dev.mk
@@ -33,5 +33,8 @@ LOCAL_C_INCLUDES := $(MESA_TOP)/include/drm-uapi
 
 LOCAL_SRC_FILES := $(DEV_FILES)
 
+LOCAL_CFLAGS := \
+           -Wno-gnu-variable-sized-type-not-at-end
+
 include $(MESA_COMMON_MK)
 include $(BUILD_STATIC_LIBRARY)


### PR DESCRIPTION
ignore the compile warning vendor/intel/external/mesa3d-intel/src/intel/dev/gen_device_info.c:938:43: warning:
field 'base' with variable sized type 'struct drm_i915_query_topology_info' not at the end of a struct or class
is a GNU extension -Wgnu-variable-sized-type-not-at-end,

ignore the compile warning vendor/intel/external/mesa3d-intel/src/intel/compiler/spirv/spirv_to_nir.c  warning:
suggest braces around initialization of subobject -Wmissing-braces

Tests: compilation with warning clean

Signed-off-by: jenny.q.cao <jenny.q.cao@intel.com>