### PR TITLE
Revert "Revert "mesa: add GL_HALF_FLOAT as supported type to readpixe…

### DIFF
--- a/src/mesa/main/readpix.c
+++ b/src/mesa/main/readpix.c
@@ -922,6 +922,8 @@ read_pixels_es3_error_check(struct gl_context *ctx, GLenum format, GLenum type,
    case GL_RGBA:
       if (type == GL_FLOAT && data_type == GL_FLOAT)
          return GL_NO_ERROR; /* EXT_color_buffer_float */
+      if (type == GL_HALF_FLOAT && data_type == GL_FLOAT)
+         return GL_NO_ERROR;
       if (type == GL_UNSIGNED_BYTE && data_type == GL_UNSIGNED_NORMALIZED)
          return GL_NO_ERROR;
       if (internalFormat == GL_RGB10_A2 &&


### PR DESCRIPTION
…ls""

This reverts commit 6b2139172969e68295c22fda92438637c7a6e6d5.

Andriod ask GL_HALF_FLOAT as supported type to readpixels. This patch
help fix CTS test android.view.cts.PixelCopyTest. However, it may cause
KHR-GLES3.packed_pixels.* regression on Linux. As CTS test is "Must Pass"
on Android, let's keep this patch as specific fix for Android.

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-63305