### PR TITLE
Revert "Revert "Revert "mesa: add GL_HALF_FLOAT as supported type to …

### DIFF
--- a/src/mesa/main/readpix.c
+++ b/src/mesa/main/readpix.c
@@ -922,8 +922,6 @@ read_pixels_es3_error_check(struct gl_context *ctx, GLenum format, GLenum type,
    case GL_RGBA:
       if (type == GL_FLOAT && data_type == GL_FLOAT)
          return GL_NO_ERROR; /* EXT_color_buffer_float */
-      if (type == GL_HALF_FLOAT && data_type == GL_FLOAT)
-         return GL_NO_ERROR;
       if (type == GL_UNSIGNED_BYTE && data_type == GL_UNSIGNED_NORMALIZED)
          return GL_NO_ERROR;
       if (internalFormat == GL_RGB10_A2 &&


### PR DESCRIPTION
…readpixels"""

This reverts commit 8aa5c8b310f6455ad82a52fc4ff082a7b4ca9a25.

Original patch, "mesa: add GL_HALF_FLOAT as supported type to readpixels"
needs to be reverted since it causes a regression with
"KHR-GLES3.packed_pixels.* tests".