### PR TITLE
BACKPORT: UPSTREAM: i965: fallback RGBX to RGBA in glEGLImageTargetRe…

### DIFF
--- a/src/mesa/drivers/dri/i965/intel_fbo.c
+++ b/src/mesa/drivers/dri/i965/intel_fbo.c
@@ -327,6 +327,35 @@ intel_alloc_renderbuffer_storage(struct gl_context * ctx, struct gl_renderbuffer
    return intel_alloc_private_renderbuffer_storage(ctx, rb, internalFormat, width, height);
 }
 
+static mesa_format
+fallback_rgbx_to_rgba(struct intel_screen *screen, struct gl_renderbuffer *rb,
+                      mesa_format original_format)
+{
+   mesa_format format = original_format;
+
+   /* The base format and internal format must be derived from the user-visible
+    * format (that is, the gl_config's format), even if we internally use
+    * choose a different format for the renderbuffer. Otherwise, rendering may
+    * use incorrect channel write masks.
+    */
+   rb->_BaseFormat = _mesa_get_format_base_format(original_format);
+   rb->InternalFormat = rb->_BaseFormat;
+
+   if (!screen->mesa_format_supports_render[original_format]) {
+      /* The glRenderbufferStorage paths in core Mesa detect if the driver
+       * does not support the user-requested format, and then searches for
+       * a fallback format. The DRI code bypasses core Mesa, though. So we do
+       * the fallbacks here.
+       *
+       * We must support MESA_FORMAT_R8G8B8X8 on Android because the Android
+       * framework requires HAL_PIXEL_FORMAT_RGBX8888 winsys surfaces.
+       */
+      format = _mesa_format_fallback_rgbx_to_rgba(original_format);
+      assert(screen->mesa_format_supports_render[format]);
+   }
+   return format;
+}
+
 static void
 intel_image_target_renderbuffer_storage(struct gl_context *ctx,
 					struct gl_renderbuffer *rb,
@@ -349,8 +378,13 @@ intel_image_target_renderbuffer_storage(struct gl_context *ctx,
       return;
    }
 
+   rb->Format = fallback_rgbx_to_rgba(brw->screen, rb, image->format);
+
+   mesa_format chosen_format = rb->Format == image->format ?
+      image->format : rb->Format;
+
    /* __DRIimage is opaque to the core so it has to be checked here */
-   if (!brw->mesa_format_supports_render[image->format]) {
+   if (!brw->mesa_format_supports_render[chosen_format]) {
       _mesa_error(ctx, GL_INVALID_OPERATION,
             "glEGLImageTargetRenderbufferStorage(unsupported image format)");
       return;
@@ -365,15 +399,12 @@ intel_image_target_renderbuffer_storage(struct gl_context *ctx,
     * content.
     */
    irb->mt = intel_miptree_create_for_dri_image(brw, image, GL_TEXTURE_2D,
-                                                image->format, false);
+                                                rb->Format, false);
    if (!irb->mt)
       return;
 
-   rb->InternalFormat = image->internal_format;
    rb->Width = image->width;
    rb->Height = image->height;
-   rb->Format = image->format;
-   rb->_BaseFormat = _mesa_get_format_base_format(image->format);
    rb->NeedsFinishRenderTexture = true;
    irb->layer_count = 1;
 }
@@ -434,27 +465,7 @@ intel_create_winsys_renderbuffer(struct intel_screen *screen,
    rb->ClassID = INTEL_RB_CLASS;
    rb->NumSamples = num_samples;
 
-   /* The base format and internal format must be derived from the user-visible
-    * format (that is, the gl_config's format), even if we internally use
-    * choose a different format for the renderbuffer. Otherwise, rendering may
-    * use incorrect channel write masks.
-    */
-   rb->_BaseFormat = _mesa_get_format_base_format(format);
-   rb->InternalFormat = rb->_BaseFormat;
-
-   rb->Format = format;
-   if (!screen->mesa_format_supports_render[rb->Format]) {
-      /* The glRenderbufferStorage paths in core Mesa detect if the driver
-       * does not support the user-requested format, and then searches for
-       * a falback format. The DRI code bypasses core Mesa, though. So we do
-       * the fallbacks here.
-       *
-       * We must support MESA_FORMAT_R8G8B8X8 on Android because the Android
-       * framework requires HAL_PIXEL_FORMAT_RGBX8888 winsys surfaces.
-       */
-      rb->Format = _mesa_format_fallback_rgbx_to_rgba(rb->Format);
-      assert(screen->mesa_format_supports_render[rb->Format]);
-   }
+   rb->Format = fallback_rgbx_to_rgba(screen, rb, format);
 
    /* intel-specific methods */
    rb->Delete = intel_delete_renderbuffer;


### PR DESCRIPTION
…nderbufferStorageOES

In the same fashion as is done for glEGLImageTextureTarget2D.

v2: share the fallback which sets baseformat and internalformat correctly
    which makes both of the tests pass (Tapani)

Fixes android.hardware.nativehardware.cts.AHardwareBufferNativeTests:

   #SingleLayer_ColorTest_GpuColorOutputCpuRead_R8G8B8X8_UNORM
   #SingleLayer_ColorTest_GpuColorOutputIsRenderable_R8G8B8X8_UNORM

Signed-off-by: Tapani Plli <tapani.palli at intel.com>

Archived-At: https://lists.freedesktop.org/archives/mesa-dev/2018-October/206292.html

Signed-off-by: Dmytro Chystiakov <dmytro.chystiakov@intel.com>
Reviewed-by: Gurchetan Singh <gurchetansingh@chromium.org>

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-70126
Change-Id: I544cba637fe5182eff1ab3566a3ec9d5195a3743