### PR TITLE
i965: setup sized internalformat for MESA_FORMAT_R10G10B10A2_UNORM

### DIFF
--- a/src/mesa/drivers/dri/i965/intel_tex_image.c
+++ b/src/mesa/drivers/dri/i965/intel_tex_image.c
@@ -633,9 +633,17 @@ intel_image_target_texture_2d(struct gl_context *ctx, GLenum target,
    struct intel_texture_object *intel_texobj = intel_texture_object(texObj);
    intel_texobj->planar_format = image->planar_format;
 
-   const GLenum internal_format =
+   GLenum internal_format =
       image->internal_format != 0 ?
       image->internal_format : _mesa_get_format_base_format(mt->format);
+
+   /* Setup a sized internal format for MESA_FORMAT_R10G10B10[X2|A2]_UNORM. */
+   if (brw->mesa_format_supports_render[image->format]) {
+      if (image->format == MESA_FORMAT_R10G10B10A2_UNORM ||
+          image->format == MESA_FORMAT_R10G10B10X2_UNORM)
+         internal_format = GL_RGB10_A2;
+   }
+
    intel_set_texture_image_mt(brw, texImage, internal_format, mt->format, mt);
    intel_miptree_release(&mt);
 }


### PR DESCRIPTION
Commit d2b60e433e5 introduced restrictions (as per GLES spec) on the
internal format. We need to setup a sized format for the texture image
so framebuffers created with that are considered complete.

This change fixes following Android CTS test in AHardwareBufferNativeTests
category:

   SingleLayer_ColorTest_GpuColorOutputAndSampledImage_R10G10B10A2_UNORM

Signed-off-by: Tapani Pälli <tapani.palli@intel.com>