### PR TITLE
Revert "egl/android: Update color_buffers querying for buffer age"

### DIFF
--- a/src/egl/drivers/dri2/egl_dri2.h
+++ b/src/egl/drivers/dri2/egl_dri2.h
@@ -333,14 +333,13 @@ struct dri2_egl_surface
    __DRIimage *dri_image_front;
 
    /* Used to record all the buffers created by ANativeWindow and their ages.
-    * Allocate number of color_buffers based on query to android bufferqueue
-    * and save color_buffers_count.
+    * Usually Android uses at most triple buffers in ANativeWindow
+    * so hardcode the number of color_buffers to 3.
     */
-   int color_buffers_count;
    struct {
       struct ANativeWindowBuffer *buffer;
       int age;
-   } *color_buffers, *back;
+   } color_buffers[3], *back;
 #endif
 
 #if defined(HAVE_SURFACELESS_PLATFORM)

--- a/src/egl/drivers/dri2/platform_android.c
+++ b/src/egl/drivers/dri2/platform_android.c
@@ -249,7 +249,7 @@ droid_window_dequeue_buffer(struct dri2_egl_surface *dri2_surf)
     * for updating buffer's age in swap_buffers.
     */
    EGLBoolean updated = EGL_FALSE;
-   for (int i = 0; i < dri2_surf->color_buffers_count; i++) {
+   for (int i = 0; i < ARRAY_SIZE(dri2_surf->color_buffers); i++) {
       if (!dri2_surf->color_buffers[i].buffer) {
          dri2_surf->color_buffers[i].buffer = dri2_surf->buffer;
       }
@@ -264,7 +264,7 @@ droid_window_dequeue_buffer(struct dri2_egl_surface *dri2_surf)
       /* In case of all the buffers were recreated by ANativeWindow, reset
        * the color_buffers
        */
-      for (int i = 0; i < dri2_surf->color_buffers_count; i++) {
+      for (int i = 0; i < ARRAY_SIZE(dri2_surf->color_buffers); i++) {
          dri2_surf->color_buffers[i].buffer = NULL;
          dri2_surf->color_buffers[i].age = 0;
       }
@@ -419,7 +419,6 @@ droid_create_surface(_EGLDriver *drv, _EGLDisplay *disp, EGLint type,
 
    if (type == EGL_WINDOW_BIT) {
       int format;
-      int buffer_count;
 
       if (window->common.magic != ANDROID_NATIVE_WINDOW_MAGIC) {
          _eglError(EGL_BAD_NATIVE_WINDOW, "droid_create_surface");
@@ -429,26 +428,6 @@ droid_create_surface(_EGLDriver *drv, _EGLDisplay *disp, EGLint type,
          _eglError(EGL_BAD_NATIVE_WINDOW, "droid_create_surface");
          goto cleanup_surface;
       }
-
-      /* Query ANativeWindow for MIN_UNDEQUEUED_BUFFER, set buffer count
-       * and allocate color_buffers.
-       */
-      if (window->query(window, NATIVE_WINDOW_MIN_UNDEQUEUED_BUFFERS,
-                        &buffer_count)) {
-         _eglError(EGL_BAD_NATIVE_WINDOW, "droid_create_surface");
-         goto cleanup_surface;
-      }
-      if (native_window_set_buffer_count(window, buffer_count+1)) {
-         _eglError(EGL_BAD_NATIVE_WINDOW, "droid_create_surface");
-         goto cleanup_surface;
-      }
-      dri2_surf->color_buffers = calloc(buffer_count+1,
-                                        sizeof(*dri2_surf->color_buffers));
-      if (!dri2_surf->color_buffers) {
-         _eglError(EGL_BAD_ALLOC, "droid_create_surface");
-         goto cleanup_surface;
-      }
-      dri2_surf->color_buffers_count = buffer_count+1;
 
       if (format != dri2_conf->base.NativeVisualID) {
          _eglLog(_EGL_WARNING, "Native format mismatch: 0x%x != 0x%x",
@@ -477,8 +456,6 @@ droid_create_surface(_EGLDriver *drv, _EGLDisplay *disp, EGLint type,
    return &dri2_surf->base;
 
 cleanup_surface:
-   if (dri2_surf->color_buffers_count)
-      free(dri2_surf->color_buffers);
    free(dri2_surf);
 
    return NULL;
@@ -531,7 +508,6 @@ droid_destroy_surface(_EGLDriver *drv, _EGLDisplay *disp, _EGLSurface *surf)
    dri2_dpy->core->destroyDrawable(dri2_surf->dri_drawable);
 
    dri2_fini_surface(surf);
-   free(dri2_surf->color_buffers);
    free(dri2_surf);
 
    return EGL_TRUE;
@@ -780,7 +756,7 @@ droid_swap_buffers(_EGLDriver *drv, _EGLDisplay *disp, _EGLSurface *draw)
       return EGL_TRUE;
    }
 
-   for (int i = 0; i < dri2_surf->color_buffers_count; i++) {
+   for (int i = 0; i < ARRAY_SIZE(dri2_surf->color_buffers); i++) {
       if (dri2_surf->color_buffers[i].age > 0)
          dri2_surf->color_buffers[i].age++;
    }


### PR DESCRIPTION
This reverts commit 87efbe488e919ee2833d0872d7bece8dc32ad630.

We got one PnP regression with 87efbe488. When we run Gfxbenchmark,
there will be 50% drop(from ~60 to ~30) for case Manhattan. Let's
revert this for a hot fix, which won't block the code integration.
We will continue to debug this issue with upstream mesa.

Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>
Tracked-On: OAM-OAM-88862