### PR TITLE
Dump batch buffer on Android

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -27,7 +27,8 @@ endif
 
 LOCAL_C_INCLUDES += \
 	$(MESA_TOP)/src \
-	$(MESA_TOP)/include
+	$(MESA_TOP)/include \
+	system/core/include
 
 MESA_VERSION := $(shell cat $(MESA_TOP)/VERSION)
 LOCAL_CFLAGS += \
@@ -47,6 +48,7 @@ LOCAL_CFLAGS += \
 # here to fix the radeonsi build.
 LOCAL_CFLAGS += \
 	-DANDROID_API_LEVEL=$(PLATFORM_SDK_VERSION) \
+	-DHAVE_ANDROID_PLATFORM \
 	-DENABLE_SHADER_CACHE \
 	-D__STDC_CONSTANT_MACROS \
 	-D__STDC_LIMIT_MACROS \

--- a/src/intel/Makefile.sources
+++ b/src/intel/Makefile.sources
@@ -130,7 +130,9 @@ DEV_FILES = \
 	dev/gen_debug.c \
 	dev/gen_debug.h \
 	dev/gen_device_info.c \
-	dev/gen_device_info.h
+	dev/gen_device_info.h \
+	dev/dump_batch_buffer.c \
+	dev/dump_batch_buffer.h
 
 GENXML_XML_FILES = \
 	genxml/gen4.xml \

--- a/src/intel/common/gen_batch_decoder.c
+++ b/src/intel/common/gen_batch_decoder.c
@@ -812,6 +812,14 @@ gen_print_batch(struct gen_batch_decode_ctx *ctx,
    struct gen_group *inst;
    const char *reset_color = ctx->flags & GEN_BATCH_DECODE_IN_COLOR ? NORMAL : "";
 
+   fprintf(ctx->fp, "batch buffer begin size:%u\n", batch_size);
+   for (p = batch; p < end; p += 8)
+   {
+      fprintf(ctx->fp, "%08x %08x %08x %08x %08x %08x %08x %08x\n",
+              p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+   }
+   fprintf(ctx->fp, "batch buffer end\n");
+
    if (ctx->n_batch_buffer_start >= 100) {
       fprintf(ctx->fp, "%s0x%08"PRIx64": Max batch buffer jumps exceeded%s\n",
               (ctx->flags & GEN_BATCH_DECODE_IN_COLOR) ? RED_COLOR : "",

--- a/src/intel/dev/dump_batch_buffer.c
+++ b/src/intel/dev/dump_batch_buffer.c
@@ -1,0 +1,43 @@
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <time.h>
+#include "gen_debug.h"
+#include "dump_batch_buffer.h"
+
+FILE *create_log_file()
+{
+   char file_name[1000]= {0};
+   char dir_name[1000] = "/data/data/android/mesa3d_intel";
+   time_t timep;
+   struct tm *p;
+   int tid;
+   time(&timep);
+   p = gmtime(&timep);
+   FILE *f = NULL;
+
+   tid = gettid();
+
+   snprintf(file_name, 100, "/data/data/android/mesa3d_intel/%04d%02d%02d_%02d%02d%02d_%u_mesa_batch.log", 1900+p->tm_year, 1 + p->tm_mon, p->tm_mday, p->tm_hour, p->tm_min, p->tm_sec, tid);
+   f = fopen(file_name, "a+");
+
+   dbg_printf("create log file %p %s, %p", p, file_name, f);
+   if (!f) {
+      dbg_printf("create file fail errno = %d reason = %s \n", errno, strerror(errno));
+   }
+   return f;
+}
+
+void close_log_file(FILE **file)
+{
+   if (*file != NULL && *file != stderr)
+   {
+      dbg_printf("close log file");
+      fclose(*file);
+      *file = stderr;
+   }
+}
+

--- a/src/intel/dev/dump_batch_buffer.h
+++ b/src/intel/dev/dump_batch_buffer.h
@@ -1,0 +1,15 @@
+#ifndef DUMP_BATCH_BUFFER_H
+#define DUMP_BATCH_BUFFER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern FILE *create_log_file();
+
+extern void close_log_file(FILE **file);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DUMP_BATCH_BUFFER_H */

--- a/src/intel/dev/gen_debug.c
+++ b/src/intel/dev/gen_debug.c
@@ -30,6 +30,9 @@
  */
 
 #include <stdlib.h>
+#ifdef HAVE_ANDROID_PLATFORM
+#include <cutils/properties.h>
+#endif
 
 #include "dev/gen_debug.h"
 #include "util/macros.h"
@@ -104,10 +107,25 @@ intel_debug_flag_for_shader_stage(gl_shader_stage stage)
    return flags[stage];
 }
 
+#ifdef HAVE_ANDROID_PLATFORM
+char* getprop(const char *argv)
+{
+	static char value[PROPERTY_VALUE_MAX];
+	char *default_value = "";
+	property_get(argv, value, default_value);
+	return value;
+}
+#endif
+
 static void
 brw_process_intel_debug_variable_once(void)
 {
+#ifdef HAVE_ANDROID_PLATFORM
+   INTEL_DEBUG = parse_debug_string(getprop("INTEL_DEBUG"), debug_control);
+   dbg_printf("%s,%d, INTEL_DEBUG:%08x\n", __FUNCTION__,__LINE__, INTEL_DEBUG);
+#else
    INTEL_DEBUG = parse_debug_string(getenv("INTEL_DEBUG"), debug_control);
+#endif
 }
 
 void


### PR DESCRIPTION
use getprop to control debug flag.
and dump batch buffer to loacl dir
/data/data/android/mesa3d_intel

dump method

adb root
adb shell

#prepare env
setenforce 0
mkdir -p /data/data/android/mesa3d_intel
chmod 777 /data/data/android
chmod 777 /data/data/android/mesa3d_intel

#enable dump
setprop INTEL_DEBUG "bat"

#disable dump
setprop INTEL_DEBUG ""