### PR TITLE
INTERNAL: add android prop to dump batch buffer in userspace

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -27,7 +27,9 @@ endif
 
 LOCAL_C_INCLUDES += \
 	$(MESA_TOP)/src \
-	$(MESA_TOP)/include
+	$(MESA_TOP)/include \
+	system/core/libcutils/include \
+	system/core/inclue
 
 MESA_VERSION := $(shell cat $(MESA_TOP)/VERSION)
 LOCAL_CFLAGS += \

--- a/src/intel/common/gen_batch_decoder.c
+++ b/src/intel/common/gen_batch_decoder.c
@@ -840,6 +840,14 @@ gen_print_batch(struct gen_batch_decode_ctx *ctx,
    struct gen_group *inst;
    const char *reset_color = ctx->flags & GEN_BATCH_DECODE_IN_COLOR ? NORMAL : "";
 
+   fprintf(ctx->fp, "batch buffer begin size:%u\n", batch_size);
+   for (p = batch; p < end; p += 8)
+   {
+      fprintf(ctx->fp, "%08x %08x %08x %08x %08x %08x %08x %08x\n",
+              p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+   }
+   fprintf(ctx->fp, "batch buffer end\n");
+
    if (ctx->n_batch_buffer_start >= 100) {
       fprintf(ctx->fp, "%s0x%08"PRIx64": Max batch buffer jumps exceeded%s\n",
               (ctx->flags & GEN_BATCH_DECODE_IN_COLOR) ? RED_COLOR : "",

--- a/src/intel/dev/gen_debug.c
+++ b/src/intel/dev/gen_debug.c
@@ -108,10 +108,28 @@ intel_debug_flag_for_shader_stage(gl_shader_stage stage)
    return flags[stage];
 }
 
+#ifdef __ANDROID__
+#include <cutils/properties.h>
+static char prop_buf[PROPERTY_VALUE_MAX] = {'\0'};
+
+static char* getprop(char *key) {
+	if(property_get(key, prop_buf, "") > 0) {
+		return prop_buf;
+	}
+	return prop_buf;
+
+}
+#endif
+
 static void
 brw_process_intel_debug_variable_once(void)
 {
+#ifdef __ANDROID__
+   INTEL_DEBUG = parse_debug_string(getprop("INTEL_DEBUG"), debug_control);
+#else
    INTEL_DEBUG = parse_debug_string(getenv("INTEL_DEBUG"), debug_control);
+#endif
+
 }
 
 void

--- a/src/mesa/drivers/dri/Android.mk
+++ b/src/mesa/drivers/dri/Android.mk
@@ -35,6 +35,7 @@ MESA_DRI_C_INCLUDES := \
 	$(addprefix $(MESA_TOP)/, $(mesa_dri_common_INCLUDES)) \
 	$(MESA_TOP)/src/gallium/include \
 	$(MESA_TOP)/src/gallium/auxiliary \
+	system/core/include \
 	external/expat/lib
 
 MESA_DRI_WHOLE_STATIC_LIBRARIES := \
@@ -47,6 +48,8 @@ MESA_DRI_WHOLE_STATIC_LIBRARIES := \
 	libmesa_util
 
 MESA_DRI_SHARED_LIBRARIES := \
+	libutilscallstack \
+	libutils \
 	libcutils \
 	libdl \
 	libglapi \

--- a/src/mesa/drivers/dri/Android.mk
+++ b/src/mesa/drivers/dri/Android.mk
@@ -35,7 +35,6 @@ MESA_DRI_C_INCLUDES := \
 	$(addprefix $(MESA_TOP)/, $(mesa_dri_common_INCLUDES)) \
 	$(MESA_TOP)/src/gallium/include \
 	$(MESA_TOP)/src/gallium/auxiliary \
-	system/core/include \
 	external/expat/lib
 
 MESA_DRI_WHOLE_STATIC_LIBRARIES := \

--- a/src/mesa/drivers/dri/i965/Makefile.sources
+++ b/src/mesa/drivers/dri/i965/Makefile.sources
@@ -79,6 +79,8 @@ i965_FILES = \
 	hsw_sol.c \
 	intel_batchbuffer.c \
 	intel_batchbuffer.h \
+	intel_batchbuffer_log.c \
+	intel_batchbuffer_log.h \
 	intel_blit.c \
 	intel_blit.h \
 	intel_buffer_objects.c \
@@ -108,7 +110,9 @@ i965_FILES = \
 	intel_tex_obj.h \
 	intel_tex_validate.c \
 	intel_upload.c \
-	libdrm_macros.h
+	libdrm_macros.h \
+	callstack.h \
+	callstack.cpp
 
 i965_gen4_FILES = \
 	genX_blorp_exec.c \

--- a/src/mesa/drivers/dri/i965/brw_bufmgr.c
+++ b/src/mesa/drivers/dri/i965/brw_bufmgr.c
@@ -649,7 +649,7 @@ retry:
 
    mtx_unlock(&bufmgr->lock);
 
-   DBG("bo_create: buf %d (%s) %llub\n", bo->gem_handle, bo->name,
+   DBG("bo_create: buf %d (%s) 0x%016llx %llub\n", bo->gem_handle, bo->name, bo->gtt_offset,
        (unsigned long long) size);
 
    return bo;

--- a/src/mesa/drivers/dri/i965/callstack.cpp
+++ b/src/mesa/drivers/dri/i965/callstack.cpp
@@ -1,0 +1,8 @@
+#include "callstack.h"
+#include <utils/CallStack.h>
+extern "C" {
+    void dumping_callstack(void)
+    {
+        android::CallStack cs("INTEL-MESA");
+    }
+}

--- a/src/mesa/drivers/dri/i965/callstack.h
+++ b/src/mesa/drivers/dri/i965/callstack.h
@@ -1,0 +1,10 @@
+#ifndef _CALLBACK_H
+#define _CALLBACK_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+    void dumping_callstack(void);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/mesa/drivers/dri/i965/intel_batchbuffer_log.c
+++ b/src/mesa/drivers/dri/i965/intel_batchbuffer_log.c
@@ -1,0 +1,34 @@
+#include "intel_batchbuffer_log.h"
+
+FILE *create_log_file()
+{
+   char file_name[1000]= {0};
+   char dir_name[1000] = "/data/data/android/mesa3d_intel";
+   time_t timep;
+   struct tm *p;
+   int tid;
+   time(&timep);
+   p = gmtime(&timep);
+   FILE *f = NULL;
+
+   tid = gettid();
+
+   snprintf(file_name, 100, "/data/data/android/mesa3d_intel/%04d%02d%02d_%02d%02d%02d_%u_mesa_batch.log", 1900+p->tm_year, p->tm_mon, p->tm_mday, p->tm_hour, p->tm_min, p->tm_sec, tid);
+   f = fopen(file_name, "a+");
+
+   dbg_printf("create log file %p %s, %p", p, file_name, f);
+   //dumping_callstack();
+   if (!f) {
+      dbg_printf("create file fail errno = %d reason = %s \n", errno, strerror(errno));
+   }
+   return f;
+}
+
+void close_log_file(FILE *file)
+{
+   if (file != NULL && file != stderr)
+   {
+      dbg_printf("close log file");
+      fclose(file);
+   }
+}

--- a/src/mesa/drivers/dri/i965/intel_batchbuffer_log.h
+++ b/src/mesa/drivers/dri/i965/intel_batchbuffer_log.h
@@ -1,0 +1,43 @@
+#ifndef INTEL_BATCHBUFFER_LOG_H
+#define INTEL_BATCHBUFFER_LOG_H
+
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <time.h>
+#include "callstack.h"
+
+#ifndef HAVE_ANDROID_PLATFORM
+#define HAVE_ANDROID_PLATFORM
+#endif
+#ifdef HAVE_ANDROID_PLATFORM
+#define LOG_TAG "INTEL-MESA"
+#if ANDROID_API_LEVEL >= 26
+#include <log/log.h>
+#else
+#include <cutils/log.h>
+#endif /* use log/log.h start from android 8 major version */
+#ifndef ALOGW
+#define ALOGW LOGW
+#endif
+#define dbg_printf(...)	ALOGW(__VA_ARGS__)
+#else
+#define dbg_printf(...)	fprintf(stderr, __VA_ARGS__)
+#endif /* HAVE_ANDROID_PLATFORM */
+
+#undef HAVE_ANDROID_PLATFORM
+
+#define DBG(...) do {						\
+	if (unlikely(INTEL_DEBUG & FILE_DEBUG_FLAG))		\
+		dbg_printf(__VA_ARGS__);			\
+} while(0)
+
+
+extern FILE *create_log_file();
+extern void close_log_file(FILE*);
+
+#endif
+


### PR DESCRIPTION
How to use the patch 
dump batch buffer on the storage
adb root
adb remount
setenforce 0

mkdir -p /data/data/android/mesa3d_intel/
chmod 777 /data/data/android/mesa3d_intel/
setprop INTEL_DEBUG "bat"

getprop |grep INTEL_DEBUG
ps -e surfaceflinger

Signed-off-by: Kanli Hu <kanlix.hu@intel.com>