### PR TITLE
i965: Explicitly abort instead of calling exit on batch buffer submission failure

### DIFF
--- a/src/mesa/drivers/dri/i965/intel_batchbuffer.c
+++ b/src/mesa/drivers/dri/i965/intel_batchbuffer.c
@@ -824,7 +824,7 @@ submit_batch(struct brw_context *brw, int in_fence_fd, int *out_fence_fd)
    if (ret != 0) {
       fprintf(stderr, "i965: Failed to submit batchbuffer: %s\n",
               strerror(-ret));
-      exit(1);
+      abort();
    }
 
    return ret;


### PR DESCRIPTION
This resolves a deadlock due to atexit handlers running, which I observed during batch buffer submission failure:
```
#0  syscall () at bionic/libc/arch-x86_64/bionic/syscall.S:59
#1  0x0000723427138d8d in __futex (op=<optimized out>, value=<optimized out>, timeout=0x0, bitset=-1, ftx=<optimized out>) at bionic/libc/private/bionic_futex.h:48
#2  __futex_wait_ex (value=<optimized out>, ftx=<optimized out>, shared=<optimized out>, use_realtime_clock=<optimized out>, abs_timeout=<optimized out>) at bionic/libc/private/bionic_futex.h:70
#3  __pthread_normal_mutex_lock (shared=0, abs_timeout_or_null=0x0, mutex=<optimized out>, use_realtime_clock=<optimized out>) at bionic/libc/bionic/pthread_mutex.cpp:327
#4  __pthread_mutex_lock_with_timeout (mutex=0x7234251e914c <_egl_TSDMutex>, use_realtime_clock=<optimized out>, abs_timeout_or_null=0x0) at bionic/libc/bionic/pthread_mutex.cpp:430
#5  0x00007234251d47e7 in mtx_lock (mtx=<optimized out>) at vendor/intel/external/mesa3d-intel/include/c11/threads_posix.h:223
#6  _eglInitTSD (dtor=<optimized out>) at vendor/intel/external/mesa3d-intel/src/egl/main/eglcurrent.c:86
#7  _eglCheckedGetTSD () at vendor/intel/external/mesa3d-intel/src/egl/main/eglcurrent.c:173
#8  _eglGetCurrentThread () at vendor/intel/external/mesa3d-intel/src/egl/main/eglcurrent.c:192
#9  0x00007234251d4d8d in _eglDestroyThreadInfo (t=<optimized out>) at vendor/intel/external/mesa3d-intel/src/egl/main/eglcurrent.c:136
#10 _eglDestroyThreadInfoCallback (t=<optimized out>) at vendor/intel/external/mesa3d-intel/src/egl/main/eglcurrent.c:162
#11 _eglFiniTSD () at vendor/intel/external/mesa3d-intel/src/egl/main/eglcurrent.c:77
#12 0x00007234251d5765 in _eglAtExit () at vendor/intel/external/mesa3d-intel/src/egl/main/eglglobals.c:94
#13 0x00007234251caf7a in __atexit_handler_wrapper () from /opt/paycom-3000/android/out/target/product/leaf_hill/symbols/vendor/lib64/egl/libGLES_mesa.so
#14 0x000072342714bb21 in __cxa_finalize (dso=0x0) at bionic/libc/stdlib/atexit.c:164
#15 0x00007234270da921 in exit (status=1) at bionic/libc/stdlib/exit.c:37
#16 0x0000723424792310 in submit_batch (brw=<optimized out>, in_fence_fd=<optimized out>, out_fence_fd=<optimized out>)
    at vendor/intel/external/mesa3d-intel/src/mesa/drivers/dri/i965/intel_batchbuffer.c:971
#17 _intel_batchbuffer_flush_fence (brw=<optimized out>, in_fence_fd=<optimized out>, out_fence_fd=<optimized out>, file=<optimized out>, line=<optimized out>)
    at vendor/intel/external/mesa3d-intel/src/mesa/drivers/dri/i965/intel_batchbuffer.c:1022
#18 0x0000723424783db8 in brw_fence_insert_locked (brw=0x723424427730, fence=<optimized out>) at vendor/intel/external/mesa3d-intel/src/mesa/drivers/dri/i965/brw_sync.c:177
#19 0x0000723424783bdd in brw_fence_insert (brw=<optimized out>, fence=<optimized out>) at vendor/intel/external/mesa3d-intel/src/mesa/drivers/dri/i965/brw_sync.c:192
#20 brw_fence_server_wait (brw=0x723424427730, fence=0x723424095e40) at vendor/intel/external/mesa3d-intel/src/mesa/drivers/dri/i965/brw_sync.c:330
#21 brw_dri_server_wait_sync (ctx=<optimized out>, _fence=0x723424095e40, flags=<optimized out>) at vendor/intel/external/mesa3d-intel/src/mesa/drivers/dri/i965/brw_sync.c:470
#22 0x00007234251da9aa in dri2_server_wait_sync (drv=<optimized out>, dpy=0x72342641c000, sync=0x723424426940) at vendor/intel/external/mesa3d-intel/src/egl/drivers/dri2/egl_dri2.c:3162
#23 0x00007234251cf573 in _eglWaitSyncCommon (disp=0x72342641c000, s=0x723424426940, flags=0) at vendor/intel/external/mesa3d-intel/src/egl/main/eglapi.c:1968
#24 0x0000723425dd877f in eglWaitSyncKHR (dpy=<optimized out>, sync=0x723424426940, flags=0) at frameworks/native/opengl/libs/EGL/eglApi.cpp:2046
#25 0x0000723425cb911c in hwcomposer::GLRenderer::InsertFence (this=0x72342642f7e0, kms_fence=<optimized out>) at vendor/intel/external/hwcomposer-intel/common/compositor/gl/glrenderer.cpp:200
#26 0x0000723425c947dc in hwcomposer::CompositorThread::Handle3DDrawRequest (this=0x7234264423c0) at vendor/intel/external/hwcomposer-intel/common/compositor/compositorthread.cpp:245
#27 0x0000723425c94650 in hwcomposer::CompositorThread::HandleRoutine (this=0x7234264423c0) at vendor/intel/external/hwcomposer-intel/common/compositor/compositorthread.cpp:131
#28 0x0000723425cb5493 in hwcomposer::HWCThread::ProcessThread (this=0x7234264423c0) at vendor/intel/external/hwcomposer-intel/common/utils/hwcthread.cpp:98
#29 0x0000723425cb55a7 in std::__1::__invoke<void (hwcomposer::HWCThread::*)(), hwcomposer::HWCThread*, , void> (__f=<optimized out>, __a0=<optimized out>) at external/libcxx/include/type_traits:4232
#30 std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (hwcomposer::HWCThread::*)(), hwcomposer::HWCThread*, 2ul> (
    __t=...) at external/libcxx/include/thread:339
#31 std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (hwcomposer::HWCThread::*)(), hwcomposer::HWCThread*> > (__vp=0x72342642e940) at external/libcxx/include/thread:349
#32 0x000072342713826c in __pthread_start (arg=0x72342564a4f0) at bionic/libc/bionic/pthread_create.cpp:226
#33 0x00007234270e6ede in __start_thread (fn=0x723427138250 <__pthread_start(void*)>, arg=0x72342564a4f0) at bionic/libc/bionic/clone.cpp:47
#34 0x00007234270e57d6 in __bionic_clone () at bionic/libc/arch-x86_64/bionic/__bionic_clone.S:80
```